### PR TITLE
Add mechanism to disable workaround for dependency groups

### DIFF
--- a/rosidl_core_generators/package.xml
+++ b/rosidl_core_generators/package.xml
@@ -16,21 +16,17 @@
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
-
-  <!-- Bloom does not support group_depend, so this unrolls rosidl_generator_packages -->
-  <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_generator_py</buildtool_export_depend>
-
-  <!-- Bloom does not support group_depend, so this unrolls rosidl_typesupport_c_packages -->
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_typesupport_fastrtps_c</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_typesupport_introspection_c</buildtool_export_depend>
-
-  <!-- Bloom does not support group_depend, so this unrolls rosidl_typesupport_cpp_packages -->
   <buildtool_export_depend>rosidl_typesupport_cpp</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_typesupport_fastrtps_cpp</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_typesupport_introspection_cpp</buildtool_export_depend>
+
+  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
+  <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_generator_c</buildtool_export_depend>
+  <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_generator_cpp</buildtool_export_depend>
+  <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_generator_py</buildtool_export_depend>
+  <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_fastrtps_c</buildtool_export_depend>
+  <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_c</buildtool_export_depend>
+  <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_fastrtps_cpp</buildtool_export_depend>
+  <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_cpp</buildtool_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosidl_core_runtime/package.xml
+++ b/rosidl_core_runtime/package.xml
@@ -14,20 +14,16 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <!-- Bloom does not support group_depend, so this unrolls rosidl_runtime_packages -->
-  <build_export_depend>rosidl_runtime_c</build_export_depend>
-  <build_export_depend>rosidl_runtime_cpp</build_export_depend>
-  <build_export_depend>rosidl_generator_py</build_export_depend>
-
-  <!-- Bloom does not support group_depend, so this unrolls rosidl_typesupport_c_packages -->
-  <build_export_depend>rosidl_typesupport_c</build_export_depend>
-  <build_export_depend>rosidl_typesupport_fastrtps_c</build_export_depend>
-  <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
-
-  <!-- Bloom does not support group_depend, so this unrolls rosidl_typesupport_cpp_packages -->
-  <build_export_depend>rosidl_typesupport_cpp</build_export_depend>
-  <build_export_depend>rosidl_typesupport_fastrtps_cpp</build_export_depend>
-  <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
+  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_generator_py</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_runtime_c</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_runtime_cpp</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_c</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_cpp</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_fastrtps_c</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_c</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_fastrtps_cpp</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_cpp</build_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
See ros-infrastructure/catkin_pkg#369

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20943)](http://ci.ros2.org/job/ci_linux/20943/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15234)](http://ci.ros2.org/job/ci_linux-aarch64/15234/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21617)](http://ci.ros2.org/job/ci_windows/21617/)