### PR TITLE
Revert "Added rosidl_generator_rs"

### DIFF
--- a/rosidl_core_generators/package.xml
+++ b/rosidl_core_generators/package.xml
@@ -23,7 +23,6 @@
   <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_generator_c</buildtool_export_depend>
   <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_generator_cpp</buildtool_export_depend>
   <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_generator_py</buildtool_export_depend>
-  <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_generator_rs</buildtool_export_depend>
   <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_fastrtps_c</buildtool_export_depend>
   <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_c</buildtool_export_depend>
   <buildtool_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_fastrtps_cpp</buildtool_export_depend>


### PR DESCRIPTION
Reverts ros2/rosidl_core#7

This needed to be merged in after `rosidl_generator_rs` is generally available in the `ros2.repos` file, which is done by this pull request: https://github.com/ros2/ros2/pull/1674

One oversight was that adding something to ros2.repos (and hence, the ROS core) also needs to be added to ROS REP 2005 https://ros.org/reps/rep-2005.html, which will additionally require a PMC vote.

After talking with @cottsay, the timeline I propose:

* This gets discussion in the ROS 2 PMC meeting tomorrow (April 15)
* I send out notification of a formal decision tomorrow (April 15)
* ROS PMC votes to accept REP2005 modifications (needs minimum 1 week) (April 22)
* We can re-land these changes in rolling as soon as the freeze is lifted (approx same time)
* This can be backported into the first kilted release.