### PR TITLE
Remove rosidl_generator_rs dependency

### DIFF
--- a/rosidl_core_generators/package.xml
+++ b/rosidl_core_generators/package.xml
@@ -21,7 +21,6 @@
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_py</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_generator_rs</buildtool_export_depend>
 
   <!-- Bloom does not support group_depend, so this unrolls rosidl_typesupport_c_packages -->
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>


### PR DESCRIPTION
Removed rosidl_generator_rs from buildtool_export_depend.

`rosidl_generator_rs` package is not part of Jazzy.

See: https://github.com/ros/rosdistro/blob/jazzy/2026-01-28/jazzy/distribution.yaml

## Description

`rosidl_generator_rs`  is not (yet) part of ros jazzy.

### Is this user-facing behavior change?

Running the recursive dependency walker on `rosidl_core` won't list `rosidl_generator_rs`.

### Did you use Generative AI?

Not even.

### Additional Information

You cannot install rosidl-generator-rs with jazzy:
```
$ sudo apt install ros-jazzy-rosidl-generator-rs
apt cannot find the package and returns an error similar to:
E: Unable to locate package ros-jazzy-rosidl-generator-rs
```
