### PR TITLE
Add rosidl_buffer_py as build_export_depend with explicit group resol…

### DIFF
--- a/rosidl_core_runtime/package.xml
+++ b/rosidl_core_runtime/package.xml
@@ -24,6 +24,7 @@
   <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_fastrtps_cpp</build_export_depend>
   <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_cpp</build_export_depend>
+  <build_export_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_buffer_py</build_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Description

Add `rosidl_buffer_py` to the explicit group resolution list in `rosidl_core_runtime/package.xml`.
This is needed to expose `rosidl_buffer_py` on `PYTHONPATH` for the `rosidl_buffer` module at test/runtime for message packages (which depend on `rosidl_default_runtime` and then `rosidl_core_runtime`).

A corresponding change is also made to mark `rosidl_buffer_py` as a member of the `rosidl_runtime_packages` group in https://github.com/ros2/rosidl/blob/native_buffer/4-rosidl_c_py/rosidl_buffer_py/package.xml#L28 in https://github.com/ros2/rosidl/pull/943.


### Is this user-facing behavior change?
No. This is an update that ensures `rosidl_buffer_py` is available in the runtime environment of all message packages, which is required by code generated by `rosidl_generator_py`.

### Did you use Generative AI?
Claude (claude-4.6-opus) via Cursor was used to assist with identifying the changes needed to 

### Additional Information
This PR is part of the broader ROS 2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399) and is specifically needed by `rosidl_buffer_py` reviewed in the PR https://github.com/ros2/rosidl/pull/943.

